### PR TITLE
#164694210 Integrate TravisCI with readme badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: python
+python: 
+
+  - "3.6"
+
+services: 
+
+  - postgresql
+
+env: 
+
+  -DJANGO=2.1 DB=postgresql
+install: 
+
+  - pip install -r requirements.txt
+before_script:
+  - psql -c 'create database testdb;' -U postgres
+  - python manage.py makemigrations
+  - python manage.py migrate
+
+script: 
+  - pytest --cov authors/
+
+after_success:
+  - coveralls
+  

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/mirest/ah-haven-space-sprinters.svg?branch=develop)](https://travis-ci.org/mirest/ah-haven-space-sprinters)
+
 Authors Haven - A Social platform for the creative at heart.
 =======
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
+coverage==4.5.3
+coveralls==1.6.0
+pytest==4.3.1
+pytest-cov==2.6.1
 Click==7.0
 Django==2.1.7
 django-cors-middleware==1.3.1


### PR DESCRIPTION
#### What does this PR do?
Have TravisCI build badge in the readme file.

#### Description of Task to be completed

- [x] Write a `.travis.yml` configuration file.

- [x] Add TravisCI integration hooks in Github repository

- [x] Sync Github repository on TravisCI domain

- [x] Attach build status badge within the repository `README.md` file

#### How can this manually be tested?
On opening Github repository [repo](https://github.com/mirest/ah-haven-space-sprinters/tree/ch-Integrate-TravisCI-164694210)

- You should see a badge descriptive of `build` in the readme
#### What are the relevant pivotal tracker stories?
#164694210