### PR TITLE
#164694215 Receive jwt token on successfull registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,6 @@ db.sqlite3
 
 #windows variables
 env.bat
+
+#visual studiocode editor files
+.vscode/

--- a/authors/apps/authentication/backends.py
+++ b/authors/apps/authentication/backends.py
@@ -1,9 +1,54 @@
-# import jwt
-#
-# from django.conf import settings
-#
-# from rest_framework import authentication, exceptions
-#
-# from .models import User
+import jwt
+
+from django.conf import settings
+
+from rest_framework import authentication, exceptions
+
+from .models import User
+
+from config.settings.default import SECRET_KEY
 
 """Configure JWT Here"""
+class JWTAuthentication(authentication.BaseAuthentication):
+	"""docstring for JWTAuthentication"""
+	authentication_header_prefix = 'Bearer'
+
+	def authenticate(self, request):
+		auth_headers = authentication.get_authorization_header(request).split()
+
+		auth_header_prefix = self.authentication_header_prefix.lower()
+
+		if not auth_headers:
+			return None
+
+		if len(auth_headers) == 1 or len(auth_headers) > 2:
+			return None
+
+		prefix = auth_headers[0].decode('utf-8')
+		token = auth_headers[1].decode('utf-8')
+
+		if prefix.lower() != auth_header_prefix:
+
+			return None
+
+		return self._authenticate_credentials(request, token)
+
+	def _authenticate_credentials(self, request, token):
+
+		try:
+			payload = jwt.decode(token, SECRET_KEY)
+		except jwt.InvalidTokenError:
+			msg = 'Invalid authentication. Could not decode token.'
+			raise exceptions.AuthenticationFailed(msg)
+
+		except jwt.ExpiredSignature:
+			msg = 'Token has expired. please login again'
+			raise exceptions.AuthenticationFailed(msg)
+
+		try:
+			user = User.objects.get(username=payload['username'])
+		except User.DoesNotExist:
+			msg = 'No user matching this token was found.'
+			raise exceptions.AuthenticationFailed(msg)
+
+		return (user, token)

--- a/authors/apps/authentication/models.py
+++ b/authors/apps/authentication/models.py
@@ -1,14 +1,20 @@
+from datetime import datetime, timedelta
+
+import jwt
+
 from django.contrib.auth.models import (
     AbstractBaseUser, BaseUserManager, PermissionsMixin
 )
 from django.db import models
+
+from config.settings.default import SECRET_KEY
 
 
 class UserManager(BaseUserManager):
     """
     Django requires that custom users define their own Manager class. By
     inheriting from `BaseUserManager`, we get a lot of the same code used by
-    Django to create a `User` for free. 
+    Django to create a `User` for free.
 
     All we have to do is override the `create_user` function which we will use
     to create `User` objects.
@@ -112,3 +118,11 @@ class User(AbstractBaseUser, PermissionsMixin):
         the user's real name, we return their username instead.
         """
         return self.username
+
+    def auth_token(self):
+        """creates a token for registration"""
+        self.encoded_jwt = jwt.encode(
+            {'username': self.username,
+             'exp': datetime.now() + timedelta(days=15)},
+            SECRET_KEY, algorithm='HS256').decode('utf-8')
+        return self.encoded_jwt

--- a/authors/apps/authentication/serializers.py
+++ b/authors/apps/authentication/serializers.py
@@ -1,3 +1,5 @@
+import jwt
+
 from django.contrib.auth import authenticate
 from rest_framework import serializers
 
@@ -15,6 +17,8 @@ class RegistrationSerializer(serializers.ModelSerializer):
         write_only=True
     )
 
+    auth_token = serializers.CharField(max_length=255, read_only=True)
+
     # The client should not be able to send a token along with a registration
     # request. Making `token` read-only handles that for us.
 
@@ -22,7 +26,7 @@ class RegistrationSerializer(serializers.ModelSerializer):
         model = User
         # List all of the fields that could possibly be included in a request
         # or response, including fields specified explicitly above.
-        fields = ['email', 'username', 'password']
+        fields = ['email', 'username', 'password', 'auth_token']
 
     def create(self, validated_data):
         # Use the `create_user` method we wrote earlier to create a new user.
@@ -33,6 +37,7 @@ class LoginSerializer(serializers.Serializer):
     email = serializers.CharField(max_length=255)
     username = serializers.CharField(max_length=255, read_only=True)
     password = serializers.CharField(max_length=128, write_only=True)
+    auth_token = serializers.CharField(max_length=225, read_only=True)
 
     def validate(self, data):
         # The `validate` method is where we make sure that the current
@@ -85,14 +90,14 @@ class LoginSerializer(serializers.Serializer):
         return {
             'email': user.email,
             'username': user.username,
-
+            'auth_token': user.auth_token,
         }
 
 
 class UserSerializer(serializers.ModelSerializer):
     """Handles serialization and deserialization of User objects."""
 
-    # Passwords must be at least 8 characters, but no more than 128 
+    # Passwords must be at least 8 characters, but no more than 128
     # characters. These values are the default provided by Django. We could
     # change them, but that would create extra work while introducing no real
     # benefit, so let's just stick with the defaults.
@@ -110,7 +115,7 @@ class UserSerializer(serializers.ModelSerializer):
         # specifying the field with `read_only=True` like we did for password
         # above. The reason we want to use `read_only_fields` here is because
         # we don't need to specify anything else about the field. For the
-        # password field, we needed to specify the `min_length` and 
+        # password field, we needed to specify the `min_length` and
         # `max_length` properties too, but that isn't the case for the token
         # field.
 

--- a/authors/apps/authentication/tests/test_base.py
+++ b/authors/apps/authentication/tests/test_base.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 from authors.apps.authentication.models import User
 from rest_framework.test import APIClient
+from django.urls import reverse
 
 
 class BaseTestClass(TestCase):
@@ -21,4 +22,27 @@ class BaseTestClass(TestCase):
             }
         }
 
+        self.update_user = {
+            "user": {
+                "username": "update",
+
+            }
+        }
+
         self.client = APIClient()
+
+    def auth_header_token(self):
+        self.client.post(
+            reverse('auth:register'),
+            data=self.user_data,
+            format='json')
+
+        response = self.client.post(
+            reverse('auth:login'),
+            data=self.user_data,
+            format='json')
+
+        self.test_token = response.data.get("auth_token")
+        self.auth_header = 'Bearer {}'.format(self.test_token)
+
+        return self.auth_header

--- a/authors/apps/authentication/tests/test_views.py
+++ b/authors/apps/authentication/tests/test_views.py
@@ -9,7 +9,7 @@ from .test_base import BaseTestClass
 
 class TestUserRoutes(BaseTestClass):
     def test_user_regsitration_with_valid_data_succeeds(self):
-    
+
         resp = self.client.post(reverse('auth:register'),
                                 content_type='application/json', data=json.dumps(self.user_data))
         self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
@@ -40,3 +40,74 @@ class TestUserRoutes(BaseTestClass):
         self.assertDictEqual(resp.data, expected_response)
         self.assertIn(
             "A user with this email and password was not found.", str(resp.data))
+
+    # test whether a token is generated on login
+    def test_login_user_login_token(self):
+        user=User.objects.create_user(username='sampleuser', email='user@sprinters.ug',password='butt3rfly1')
+        user.is_active=True
+        user.save()
+
+        response = self.client.post(
+            reverse('auth:login'),
+            data=self.user_data,
+            format='json')
+        self.assertIn('auth_token', response.data)
+        self.assertEqual(response.status_code, 200)
+
+# test whether a token is generated on signup
+    def test_signup_user_signup_token(self):
+        response = self.client.post(
+            reverse('auth:register'),
+            data=self.user_data,
+            format='json')
+        self.assertIn('auth_token', response.data)
+        self.assertEqual(response.status_code, 201)
+
+    def test_invalid_token(self):
+        self.client.credentials(HTTP_AUTHORIZATION='Bearer dffg.ssddd.ghg5')
+        response = self.client.put(
+            reverse('auth:updateRetrieve'),
+            data=self.update_user,
+            format='json')
+        self.assertIn(
+            "Invalid authentication. Could not decode token.", str(response.data))
+        self.assertEqual(response.status_code, 403)
+
+
+    def test_user_with_valid_token(self):
+        self.client.credentials(HTTP_AUTHORIZATION=self.auth_header_token())
+        response = self.client.put(
+            reverse('auth:updateRetrieve'),
+            data=self.update_user,
+            format='json')
+        self.assertEqual(response.status_code, 200)
+
+    def test_upate_user_no_auth_token_header(self):
+        response = self.client.put(
+            reverse('auth:updateRetrieve'),
+            data=self.update_user,
+            format='json')
+        self.assertIn(
+            "Authentication credentials were not provided.", str(response.data))
+        self.assertEqual(response.status_code, 403)
+
+    def test_wrong_auth_header_prefix(self):
+        self.client.credentials(HTTP_AUTHORIZATION='token eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImhocGtsbXVyampra2trZyIsImV4cCI6MTU1NTAxMTg0M30.7eLjTWCAisjs8mwrfsmlrqPNcO13bv3Tp_t8Xi-okms')
+        response = self.client.put(
+            reverse('auth:updateRetrieve'),
+            data=self.update_user,
+            format='json')
+        self.assertIn(
+            "Authentication credentials were not provided.", str(response.data))
+        self.assertEqual(response.status_code, 403)
+
+    def test_invalid_length_of_token(self):
+        self.client.credentials(HTTP_AUTHORIZATION='bearer ssds.fdfd gfggg')
+        response = self.client.put(
+            reverse('auth:updateRetrieve'),
+            data=self.update_user,
+            format='json')
+        self.assertEqual(response.status_code, 403)
+
+
+

--- a/authors/apps/authentication/urls.py
+++ b/authors/apps/authentication/urls.py
@@ -5,7 +5,7 @@ from .views import (
 )
 
 urlpatterns = [
-    path('user/', UserRetrieveUpdateAPIView.as_view()),
-    path('users/', RegistrationAPIView.as_view() ,name='register'),
-    path('users/login/', LoginAPIView.as_view(),name='login'),
+    path('user/', UserRetrieveUpdateAPIView.as_view(), name ="updateRetrieve"),
+    path('users/', RegistrationAPIView.as_view(), name='register'),
+    path('users/login/', LoginAPIView.as_view(), name='login'),
 ]

--- a/authors/apps/authentication/views.py
+++ b/authors/apps/authentication/views.py
@@ -1,8 +1,11 @@
+import jwt
+
 from rest_framework import status
 from rest_framework.generics import RetrieveUpdateAPIView
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from rest_framework.generics import ListCreateAPIView
 
 from .renderers import UserJSONRenderer
 from .serializers import (

--- a/config/settings/default.py
+++ b/config/settings/default.py
@@ -108,7 +108,7 @@ REST_FRAMEWORK = {
     'EXCEPTION_HANDLER': 'authors.apps.core.exceptions.core_exception_handler',
     'NON_FIELD_ERRORS_KEY': 'error',
 
-    # 'DEFAULT_AUTHENTICATION_CLASSES': (
-    #     'authors.apps.authentication.backends.JWTAuthentication',
-    # ),
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+         'authors.apps.authentication.backends.JWTAuthentication',
+    ),
 }


### PR DESCRIPTION
**What does this PR do?**
 
Create a  JWT token for a new registered user  

**Description of Task to be completed?**

- register new user  
- receive jwt token on successfull registration
- receive jwt token when a user sucessfully logs in
- authenticate a user to to acess restricted endpoints

**How should this be manually tested?**

**To test locally**
- clone the repo and make a virtual environment venv 
- install requirements using (pip install -r requirements.txt)
- add the environment variables to the .env file and install them(python source .env) 
- run and apply migrations (python manage.py makemigrations) then (manage.py migrate)
- finally run the server 

**postman** 
* key: content-type value: application/json
* to test authentication add this to header, (key:Authorization value: Bearer token). get token from login or signup endpoint  
* registration data {"user":{"email":"examplemail.com","username":"examplename","password":"examplepassword"}}
* user update data {"user":{"username":"updatename"}}
* enpoits post(api/users), post(api/users/login) and put(api/user)

**testing online**
- alternatively visit the review app on heroku and create a new user with email,username and password

**What are the relevant pivotal tracker stories?**

#164694215]

**Screenshots**
- login data
![login data](https://user-images.githubusercontent.com/40593659/55150083-78f9f900-515c-11e9-8d2a-76b90744eca2.PNG)
- signup data
![data format](https://user-images.githubusercontent.com/40593659/55150199-b5c5f000-515c-11e9-9c2d-7271bdf8a90c.PNG)
- update user data
![update data](https://user-images.githubusercontent.com/40593659/55150259-d3935500-515c-11e9-8dec-63ed51c0077b.PNG)
- when there is no token in the headers
![no auth token](https://user-images.githubusercontent.com/40593659/55150333-fcb3e580-515c-11e9-86be-0942ae5e7579.PNG)
- when the token is invalid
![invalid token](https://user-images.githubusercontent.com/40593659/55150457-35ec5580-515d-11e9-8946-922034f93e7e.PNG)
- when a user successfully signs up
![successfull signup token](https://user-images.githubusercontent.com/40593659/55150537-5caa8c00-515d-11e9-827d-c93876448987.PNG)
- when the token used to access a restricted endpoint is valid
![valid token](https://user-images.githubusercontent.com/40593659/55150589-7d72e180-515d-11e9-9d2b-3430b051bae9.PNG)
