### PR TITLE
 #164694233 Add pagination support to articles

### DIFF
--- a/authors/apps/articles/pagination.py
+++ b/authors/apps/articles/pagination.py
@@ -1,0 +1,9 @@
+from rest_framework.pagination import LimitOffsetPagination
+
+
+class ArticleOffsetPagination(LimitOffsetPagination):
+    """ Set articles to only 5 articles per page
+    """
+
+    default_limit = 5
+    offset_query_param = "offset"

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -15,6 +15,7 @@ from rest_framework.response import Response
 
 from config.settings import default
 from .models import Article
+from .pagination import ArticleOffsetPagination
 from .renderers import ArticleJSONRenderer
 from .serializers import (
      ArticleSerializer
@@ -27,9 +28,11 @@ from authors.apps.authentication.models import User
 class ArticleView(ListCreateAPIView):
     """creating, viewing , deleting and updating articles"""
 
+    queryset = Article.objects.all()
     permission_classes = (IsAuthenticatedOrReadOnly,)
     renderer_classes = (ArticleJSONRenderer, )
     serializer_class = ArticleSerializer
+    pagination_class = ArticleOffsetPagination
 
 
     def post(self, request):
@@ -43,11 +46,6 @@ class ArticleView(ListCreateAPIView):
 
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
-    def get(self, request):
-        queryset = Article.objects.all()
-        # the many param informs the serializer that it will be serializing more than a single article.
-        serializer = self.serializer_class(queryset, many=True)
-        return Response({"articles": serializer.data})
 
 class ArticleRetrieveUpdateDelete(RetrieveUpdateDestroyAPIView):
 


### PR DESCRIPTION
**What does this PR do?**

- Adds pagination support to articles endpoint

**Description of tasks to be completed?**

- Add a custom pagination class and specify the number of items per page
- Add the offset query parameter
- Have five articles per page

**How should this be manually tested?**

- once articles have been created
- visit `get api/articles/` endpoint
- There should be 5 articles returned per page

**What are the relevant Pivotal Tracker stories?**

#164694233

**Screenshots**

![pag2](https://user-images.githubusercontent.com/40593659/55719931-221bdb80-5a08-11e9-8c36-6ac82bb51c2f.PNG)
