### PR TITLE
#164694237 Share Articles across different channels

### DIFF
--- a/authors/apps/articles/renderers.py
+++ b/authors/apps/articles/renderers.py
@@ -1,7 +1,10 @@
-import json
-
 from authors.apps.authentication.default_renderer import BaseRenderer
 
 
 class ArticleJSONRenderer(BaseRenderer):
     data = 'article'
+
+
+class ArticleShareLinkRenderer(BaseRenderer):
+    # Returns social media share links
+    data = 'link'

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -58,3 +58,13 @@ class ArticleSerializer(serializers.ModelSerializer):
         instance.save()
 
         return instance
+
+
+class EmailSerializer(serializers.Serializer):
+    email = serializers.EmailField()
+
+    class Meta:
+        # List all of the fields that could possibly be included in a request
+        # or response, including fields specified explicitly above.
+
+        fields = ['email', ]

--- a/authors/apps/articles/tests/test_base.py
+++ b/authors/apps/articles/tests/test_base.py
@@ -92,6 +92,10 @@ class BaseTestClass(TestCase):
 
         }
 
+        self.email_share = {
+                "email": "user@sprinters.ug",
+        }
+
         self.client = APIClient()
 
         self.client.post(reverse('auth:register'),

--- a/authors/apps/articles/tests/test_views.py
+++ b/authors/apps/articles/tests/test_views.py
@@ -96,3 +96,28 @@ class TestUserRoutes(BaseTestClass):
             reverse('article:get_article', kwargs={'slug': "how-to-train-your-dragon"}), format='json')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(str(response.data['read_time']), "4 mins")
+
+    def test_share_facebook_link(self):
+        self.client.credentials(HTTP_AUTHORIZATION=self.auth_header)
+        self.client.post(
+            reverse('article:create_article'), data=self.article_data, format='json')
+        response = self.client.post(
+            reverse('article:share_facebook', kwargs={'slug':"how-to-train-your-dragon"}), format='json')
+        self.assertEqual(response.status_code, 200)
+
+    def test_share_twitter_link(self):
+        self.client.credentials(HTTP_AUTHORIZATION=self.auth_header)
+        self.client.post(
+            reverse('article:create_article'), data=self.article_data, format='json')
+        response = self.client.post(
+            reverse('article:share_twitter', kwargs={'slug':"how-to-train-your-dragon"}), format='json')
+        self.assertEqual(response.status_code, 200)
+
+    def test_share_article_via_mail(self):
+        self.client.credentials(HTTP_AUTHORIZATION=self.auth_header)
+        self.client.post(
+            reverse('article:create_article'), data=self.article_data, format='json')
+        response = self.client.post(
+            reverse('article:share_email', kwargs={'slug':"how-to-train-your-dragon"}), data=self.email_share, format='json')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('Your article has been shared successfully', str(response.data))

--- a/authors/apps/articles/urls.py
+++ b/authors/apps/articles/urls.py
@@ -1,10 +1,17 @@
 from django.urls import path
 
 from .views import (
-     ArticleView, ArticleRetrieveUpdateDelete
+    ArticleView, ArticleRetrieveUpdateDelete, ShareFacebookView,
+    ShareTwitterView, ShareEmailView
 )
 
 urlpatterns = [
     path('articles/', ArticleView.as_view(), name='create_article'),
     path('articles/<slug>', ArticleRetrieveUpdateDelete.as_view(), name='get_article'),
+    path('articles/<slug>/share/facebook',
+         ShareFacebookView.as_view(), name='share_facebook'),
+    path('articles/<slug>/share/twitter',
+         ShareTwitterView.as_view(), name='share_twitter'),
+    path('articles/<slug>/share/email',
+         ShareEmailView.as_view(), name='share_email'),
 ]

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -9,16 +9,18 @@ from django.utils.encoding import force_bytes
 from django.utils.encoding import force_text
 from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
 from rest_framework import status
-from rest_framework.generics import ListCreateAPIView, RetrieveUpdateDestroyAPIView
+from rest_framework.views import APIView
+from rest_framework.generics import ListCreateAPIView, RetrieveUpdateDestroyAPIView, CreateAPIView
 from rest_framework.permissions import AllowAny, IsAuthenticated, IsAuthenticatedOrReadOnly
 from rest_framework.response import Response
 
 from config.settings import default
 from .models import Article
 from .pagination import ArticleOffsetPagination
-from .renderers import ArticleJSONRenderer
+from .renderers import (
+    ArticleJSONRenderer, ArticleShareLinkRenderer)
 from .serializers import (
-     ArticleSerializer
+    ArticleSerializer, EmailSerializer
 )
 
 from authors.apps.profiles.models import Profile
@@ -39,7 +41,8 @@ class ArticleView(ListCreateAPIView):
         article = request.data
 
         # Create an article from the above data
-        serializer = self.serializer_class(data=article, context=serializer_context)
+        serializer = self.serializer_class(
+            data=article, context=serializer_context)
         serializer.is_valid(raise_exception=True)
         serializer.save()
 
@@ -54,11 +57,9 @@ class ArticleRetrieveUpdateDelete(RetrieveUpdateDestroyAPIView):
     queryset = Article.objects.all()
     lookup_field = 'slug'
 
-
     def get_object(self, *args, **kwargs):
         slug = self.kwargs.get("slug")
         return get_object_or_404(Article, slug=slug)
-
 
     def destroy(self, request, slug):
 
@@ -68,13 +69,12 @@ class ArticleRetrieveUpdateDelete(RetrieveUpdateDestroyAPIView):
         if not is_author:
             resp = {"message": "you can't delete this article"}
             return Response(resp,
-                        status=status.HTTP_403_FORBIDDEN)
+                            status=status.HTTP_403_FORBIDDEN)
         self.perform_destroy(article)
-        resp = {"message":"Article has been deleted"}
+        resp = {"message": "Article has been deleted"}
         return Response(resp)
 
-
-    def update(self, request, slug,*args,**kwargs):
+    def update(self, request, slug, *args, **kwargs):
 
         article = self.get_object(slug)
         requester = Profile.objects.get(user=request.user)
@@ -82,7 +82,7 @@ class ArticleRetrieveUpdateDelete(RetrieveUpdateDestroyAPIView):
         if not is_author:
             resp = {"message": "you can't update this article"}
             return Response(resp,
-                        status=status.HTTP_403_FORBIDDEN)
+                            status=status.HTTP_403_FORBIDDEN)
 
         serializer_data = request.data
         serializer = self.serializer_class(
@@ -91,3 +91,88 @@ class ArticleRetrieveUpdateDelete(RetrieveUpdateDestroyAPIView):
         serializer.is_valid(raise_exception=True)
         serializer.save()
         return Response(serializer.data)
+
+
+class ShareFacebookView(APIView):
+    """creating links for sharing articles via facebook
+    """
+
+    permission_classes = (IsAuthenticated,)
+    renderer_classes = (ArticleShareLinkRenderer, )
+
+    def get_object(self, *args, **kwargs):
+        slug = self.kwargs.get("slug")
+        return get_object_or_404(Article, slug=slug)
+
+    def post(self, request, slug, *args, **kwargs):
+        self.get_object(slug)
+        current_url = 'https://{}'.format(get_current_site(request))
+        route = 'api/articles'
+
+        url = "{}/{}/{}".format(current_url, route, slug)
+
+        facebook_url = "https://www.facebook.com/sharer/sharer.php?u="
+        message = {"Facebook_link": facebook_url + url}
+
+        return Response(message)
+
+
+class ShareTwitterView(APIView):
+    """creating links for sharing articles via facebook
+    """
+
+    permission_classes = (IsAuthenticated,)
+    renderer_classes = (ArticleShareLinkRenderer, )
+
+    def get_object(self, *args, **kwargs):
+        slug = self.kwargs.get("slug")
+        return get_object_or_404(Article, slug=slug)
+
+    def post(self, request, slug, *args, **kwargs):
+        self.get_object(slug)
+        current_url = 'https://{}'.format(get_current_site(request))
+        route = 'api/articles'
+
+        url = "{}/{}/{}".format(current_url, route, slug)
+
+        twitter_url = "https://twitter.com/home?status="
+        message = {"twitter_link": twitter_url + url}
+
+        return Response(message)
+
+
+class ShareEmailView(CreateAPIView):
+    """creating links for sharing articles via facebook
+    """
+
+    permission_classes = (IsAuthenticated,)
+    renderer_classes = (ArticleShareLinkRenderer, )
+    serializer_class = EmailSerializer
+
+    def get_object(self, *args, **kwargs):
+        slug = self.kwargs.get("slug")
+        return get_object_or_404(Article, slug=slug)
+
+    def post(self, request, slug, *args, **kwargs):
+        reciever_mail = request.data
+        serializer = self.serializer_class(data=reciever_mail)
+        serializer.is_valid(raise_exception=True)
+        email = serializer.data['email']
+        article = self.get_object(slug)
+        title = article.title
+        username = request.user.username
+        current_url = 'https://{}'.format(get_current_site(request))
+        route = 'api/articles'
+
+        url = "{}/{}/{}".format(current_url, route, slug)
+
+        from_email = default.DEFAULT_FROM_EMAIL
+        to_mail = [email]
+        subject = "Authors Haven"
+        body = "{} shared an article about {}.\
+             Click here to view article {}".format(
+            username, title, url)
+        send_mail(subject, body, from_email, to_mail, fail_silently=False)
+        message = {"message": "Your article has been shared successfully"}
+
+        return Response(message)


### PR DESCRIPTION
**What does this PR do?**

- Enables articles to be shared across Facebook, Twitter and via Email

**Description of Task to be completed?**

- Add endpoints for sharing articles
- Authors should receive share links of Facebook and Twitter
- Authors should be able to share articles via emails

**How should this be manually tested?**

- Given articles that have already been created
- visit the following endpoints  `post articles/<slug>/share/facebook` and `post articles/<slug>/share/twitter` for facebook and twitter
- To test sharing via email `post articles/<slug>/share/email` with data {"email":"receivermail"}

**What are the relevant pivotal tracker stories?**

#164694237

**Screenshots**

![facebook](https://user-images.githubusercontent.com/40593659/55793979-d0895480-5acc-11e9-8d6c-1840f71b5345.PNG)

![twitter](https://user-images.githubusercontent.com/40593659/55794047-ef87e680-5acc-11e9-9024-d607086d9529.PNG)

![email](https://user-images.githubusercontent.com/40593659/55794090-0c241e80-5acd-11e9-9956-90450248d3ee.PNG)
